### PR TITLE
Normalize declaration names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 1.1.1
+* Bug fix: Normalize variable, property and function names
+
 ## Version 1.1
 * Basic support for classes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspicl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A javascript to pico-8 lua converter",
   "main": "build/jspicl.js",
   "module": "src/index.js",

--- a/src/declarations/functionDeclaration.js
+++ b/src/declarations/functionDeclaration.js
@@ -1,4 +1,5 @@
 import transpile from "../transpile";
+import { normalizeName } from "../helpers";
 
 // http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#function-declaration
 export const FunctionDeclaration = ({ id, body, params }) => {
@@ -7,7 +8,7 @@ export const FunctionDeclaration = ({ id, body, params }) => {
   const functionContent = transpile(body);
 
   return `
-function ${name}(${argumentList})
+function ${normalizeName(name)}(${argumentList})
   ${functionContent}
 end`;
 };

--- a/src/declarations/variableDeclarator.js
+++ b/src/declarations/variableDeclarator.js
@@ -1,9 +1,10 @@
 import transpile from "../transpile";
+import { normalizeName } from "../helpers";
 
 // http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#variable-declaration
 export const VariableDeclarator = ({ id, init }) => {
   const { name } = id;
   const value = transpile(init) || "nil";
 
-  return `local ${name} = ${value}`;
+  return `local ${normalizeName(name)} = ${value}`;
 };

--- a/src/expressions/callExpression.js
+++ b/src/expressions/callExpression.js
@@ -14,5 +14,5 @@ export const CallExpression = ({ callee, arguments: args }) => {
   }
 
   // Regular function call
-  return `${callee.name}(${argumentList})`;
+  return `${transpile(callee)}(${argumentList})`;
 };

--- a/src/expressions/functionExpression.js
+++ b/src/expressions/functionExpression.js
@@ -1,12 +1,8 @@
-import transpile from "../transpile";
+import { FunctionDeclaration } from "../declarations";
 
 // http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#function-expression
-export const FunctionExpression = ({ id, params, body }) => {
-  const { name = "" } = id || {};
-  const argumentList = transpile(params, { arraySeparator: ", " });
-  const functionContent = transpile(body);
-
-  return `function ${name}(${argumentList})
-    ${functionContent}
-  end`;
-};
+export const FunctionExpression = args =>
+  FunctionDeclaration({
+    ...args,
+    id: null
+  });

--- a/src/expressions/identifier.js
+++ b/src/expressions/identifier.js
@@ -1,9 +1,11 @@
+import { normalizeName } from "../helpers";
+
 const specialCases = {
   undefined: "nil"
 };
 
 // http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#identifier
 export const Identifier = ({ name, value }) => {
-  const identifier = (value || name).replace(/\$/g, "_");
+  const identifier = normalizeName(value || name);
   return specialCases.hasOwnProperty(identifier) && specialCases[identifier] || identifier;
 };

--- a/src/expressions/property.js
+++ b/src/expressions/property.js
@@ -1,8 +1,9 @@
 import transpile from "../transpile";
+import { normalizeName } from "../helpers";
 
 // http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#object-expression
 export const Property = ({ key, value }) => {
   const { name } = key;
 
-  return `${name} = ${transpile(value)}`;
+  return `${normalizeName(name)} = ${transpile(value)}`;
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,1 @@
+export const normalizeName = name => name.replace(/\$/g, "_");


### PR DESCRIPTION
Strips away `$` from functions, variables and properties.

Fixes #47